### PR TITLE
Feature - Parse JSON into system tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ dkms.conf
 
 build/
 .vscode
-*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,4 @@ dkms.conf
 
 build/
 .vscode
-
-.qt
+*.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,32 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Name of the project
+# Project name
 project(SystemTreePlugin)
-
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-add_library(SystemTreePlugin SHARED src/SystemTreePlugin.cpp)
-target_link_libraries(SystemTreePlugin Qt6::Core Qt6::Widgets)
+# TODO: Not sure if this is the best way to do this.
+# Define variables for include and library paths
+set(CUBEGUI_INCLUDE_DIR /opt/cubegui/include/cubegui)
+set(CUBELIB_INCLUDE_DIR /usr/local/include/cubelib)
+set(QT_INCLUDE_DIR /home/aashika/Qt6.8.0/6.8.0/gcc_64/include)
+
+set(CUBEGUI_LIB_DIR /opt/cubegui/lib)
+set(CUBELIB_LIB_DIR /usr/local/include/cubelib)
+set(QT_LIB_DIR /home/aashika/Qt6.8.0/6.8.0/gcc_64/lib)
+
+include_directories(${CUBEGUI_INCLUDE_DIR} ${CUBELIB_INCLUDE_DIR} ${QT_INCLUDE_DIR})
+link_directories(${CUBEGUI_LIB_DIR} ${CUBELIB_LIB_DIR} ${QT_LIB_DIR})
+
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+
+add_library(SystemTreePlugin SHARED
+    src/SystemTreePlugin.cpp
+    src/SystemTreePlugin.h
+)
+target_link_libraries(SystemTreePlugin
+    Qt6::Core
+    Qt6::Widgets
+)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+rm -rf build
+mkdir build
+cd build
+cmake ..
+make

--- a/src/SystemTreePlugin.cpp
+++ b/src/SystemTreePlugin.cpp
@@ -1,5 +1,22 @@
 #include "SystemTreePlugin.h"
-#include <PluginServices.h>
+#include "PluginServices.h"
+
+void SystemTreePlugin::version(int& major, int& minor, int& bugfix) const
+{
+    major = 1;
+    minor = 0;
+    bugfix = 0;
+}
+
+QString SystemTreePlugin::name() const
+{
+    return "SystemTreePlugin";
+}
+
+QString SystemTreePlugin::getHelpText() const
+{
+    return "This plugin visualizes system tree data in json.";
+}
 
 SystemTreePlugin::SystemTreePlugin()
 {

--- a/src/SystemTreePlugin.cpp
+++ b/src/SystemTreePlugin.cpp
@@ -1,6 +1,7 @@
 #include "SystemTreePlugin.h"
 #include "PluginServices.h"
 
+// Sets the version of the plugin
 void SystemTreePlugin::version(int& major, int& minor, int& bugfix) const
 {
     major = 1;
@@ -8,33 +9,78 @@ void SystemTreePlugin::version(int& major, int& minor, int& bugfix) const
     bugfix = 0;
 }
 
+// Returns the name of the plugin
 QString SystemTreePlugin::name() const
 {
     return "SystemTreePlugin";
 }
 
+// Provides a brief description of the plugin's functionality
 QString SystemTreePlugin::getHelpText() const
 {
     return "This plugin visualizes system tree data in json.";
 }
 
+// Constructor: Initializes the tree widget
 SystemTreePlugin::SystemTreePlugin()
 {
     treeWidget = new QTreeWidget();
     treeWidget->setHeaderLabel("System Tree");
 }
 
+// Destructor: Cleans up allocated resources
 SystemTreePlugin::~SystemTreePlugin()
 {
     delete treeWidget;
 }
 
+// Called when a cube file is opened; sets up the plugin's tab and loads example JSON data
 bool SystemTreePlugin::cubeOpened(cubepluginapi::PluginServices* service)
 {
+    // Add the plugin's tab to the system view
     service->addTab(cubepluginapi::SYSTEM, this);
+
+    QString exampleJson = R"({"A": {"B1": {"C1": {}, "C2": {}}, "B2": {"C3": {}, "C4": {}}}})";
+    loadJson(exampleJson);
+
+    return true;
 }
 
+// Called when a cube file is closed; clears the tree widget
 void SystemTreePlugin::cubeClosed()
 {
     treeWidget->clear();
+}
+
+// Parses and loads JSON data into the tree widget
+void SystemTreePlugin::loadJson(const QString& jsonStr)
+{
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(jsonStr.toUtf8());
+    if (!jsonDoc.isObject()) {
+        return; // Exit if the JSON is not an object
+    }
+
+    treeWidget->clear();
+    parseJson(jsonDoc.object(), nullptr);
+}
+
+// Recursively parses a JSON object and populates the tree widget
+void SystemTreePlugin::parseJson(const QJsonObject& jsonObject, QTreeWidgetItem* parentItem)
+{
+    for (const QString& key : jsonObject.keys()) {
+        QTreeWidgetItem* item = new QTreeWidgetItem();
+        item->setText(0, key);
+
+        // Add the item to the parent or as a top-level item
+        if (parentItem) {
+            parentItem->addChild(item);
+        } else {
+            treeWidget->addTopLevelItem(item);
+        }
+
+        // If the value is a nested object, recursively parse it
+        if (jsonObject[key].isObject()) {
+            parseJson(jsonObject[key].toObject(), item);
+        }
+    }
 }

--- a/src/SystemTreePlugin.h
+++ b/src/SystemTreePlugin.h
@@ -28,8 +28,12 @@ public:
     QWidget* widget() override { return treeWidget; }
     QString label() const override { return "System Tree"; }
 
+    void loadJson(const QString& jsonStr);
+
 private:
     QTreeWidget* treeWidget;
+
+    void parseJson(const QJsonObject& jsonObject, QTreeWidgetItem* parentItem);
 };
 
 #endif

--- a/src/SystemTreePlugin.h
+++ b/src/SystemTreePlugin.h
@@ -5,20 +5,28 @@
 #include <QtPlugin>
 #include <QWidget>
 #include <QTreeWidget>
-#include <CubePlugin.h>
-#include <PluginInterface.h>
 
-class SystemTreePlugin : public QObject, public cubepluginapi::CubePlugin, public cubegui::TabInterface
+#include "PluginServices.h"
+#include "CubePlugin.h"
+#include "TabInterface.h"
+
+class SystemTreePlugin : public QObject, public cubepluginapi::CubePlugin, public cubepluginapi::TabInterface
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "SystemTreePlugin")
-    Q_INTERFACES(CubePlugin)
+    Q_INTERFACES( cubepluginapi::CubePlugin )
 
 public:
     explicit SystemTreePlugin();
     ~SystemTreePlugin();
     bool cubeOpened( cubepluginapi::PluginServices* service ) override;
     void cubeClosed() override;
+    void version(int& major, int& minor, int& bugfix) const override;
+    QString name() const override;
+    QString getHelpText() const override;
+
+    QWidget* widget() override { return treeWidget; }
+    QString label() const override { return "System Tree"; }
 
 private:
     QTreeWidget* treeWidget;


### PR DESCRIPTION
This feature does the following:
- [x] Modify boilerplate to avoid build errors on plugin name or undefined references
- [x] Add logic to load custom JSON and parse it into a tree 
- [x] Comment code wherever necessary for more context 