### PR TITLE
Fix - CubeGUI Plugin Loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,26 +7,33 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-# TODO: Not sure if this is the best way to do this.
-# Define variables for include and library paths
+#TODO: Not sure if this is the best way to do this
+#Define variables for include and library paths
 set(CUBEGUI_INCLUDE_DIR /opt/cubegui/include/cubegui)
-set(CUBELIB_INCLUDE_DIR /usr/local/include/cubelib)
-set(QT_INCLUDE_DIR /home/aashika/Qt6.8.0/6.8.0/gcc_64/include)
+
+include_directories("/home/aashika/Qt/5.15.18/gcc_64/include"
+"/usr/local/include/cubelib"
+"/home/aashika/Downloads/Softwares/cubelib-4.8.2/src/cube/include" 
+"/opt/cube/include/cubelib"
+"/home/aashika/Downloads/Softwares/cubegui-4.8.2/src/GUI-qt/display"
+"/home/aashika/Qt/5.15.18/Src/qt3d/src/3rdparty/assimp/src/include/assimp"
+)
 
 set(CUBEGUI_LIB_DIR /opt/cubegui/lib)
 set(CUBELIB_LIB_DIR /usr/local/include/cubelib)
-set(QT_LIB_DIR /home/aashika/Qt6.8.0/6.8.0/gcc_64/lib)
+set(QT_LIB_DIR /home/aashika/Qt/5.15.18/gcc_64/lib)
 
-include_directories(${CUBEGUI_INCLUDE_DIR} ${CUBELIB_INCLUDE_DIR} ${QT_INCLUDE_DIR})
-link_directories(${CUBEGUI_LIB_DIR} ${CUBELIB_LIB_DIR} ${QT_LIB_DIR})
+include_directories(${CUBEGUI_INCLUDE_DIR} ${CUBELIB_INCLUDE_DIR})
 
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+set(CMAKE_PREFIX_PATH "/home/aashika/Qt/5.15.18/gcc_64/lib/cmake/Qt5")
+
+find_package(Qt5 5.15.18 REQUIRED COMPONENTS Core Widgets)
 
 add_library(SystemTreePlugin SHARED
     src/SystemTreePlugin.cpp
     src/SystemTreePlugin.h
 )
-target_link_libraries(SystemTreePlugin
-    Qt6::Core
-    Qt6::Widgets
+target_link_libraries(SystemTreePlugin PRIVATE
+    Qt5::Core
+    Qt5::Widgets
 )

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A plugin for CubeGUI that visualizes system tree data in JSON format.
 
 ## Build Instructions
+To build the plugin, make sure you have **Qt 5.15.18** installed, as cubegui-4.8.2 is not compatible with Qt 6.
+
 To build the plugin, simply run the `build.sh` script located in the project directory:
 ```bash
 bash ./build.sh


### PR DESCRIPTION
Qt version 6 was causing issues with loading the plugin on CubeGUI. Reverting to Qt5 seems to have fixed the issue.

Changelog:
- [x] Change CMakeLists to use Qt5 instead of Qt6. 
- [x] Update build instructions in readme to require Qt5. 